### PR TITLE
Add missing comma in single-element tuple.

### DIFF
--- a/pretty.py
+++ b/pretty.py
@@ -385,7 +385,7 @@ class GroupQueue(object):
             pass
 
 
-_baseclass_reprs = (object.__repr__)
+_baseclass_reprs = (object.__repr__,)
 
 
 def _default_pprint(obj, p, cycle):


### PR DESCRIPTION
Failing test case:

``` python
from pretty import pprint
pprint(object())
```

results in:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "$PREFIX/lib/python3.2/site-packages/pretty.py", line 106, in pprint
    printer.pretty(obj)
  File "$PREFIX/lib/python3.2/site-packages/pretty.py", line 299, in pretty
    return _default_pprint(obj, self, cycle)
  File "$PREFIX/lib/python3.2/site-packages/pretty.py", line 397, in _default_pprint
    if getattr(klass, '__repr__', None) not in _baseclass_reprs:
TypeError: argument of type 'wrapper_descriptor' is not iterable
```
