### PR TITLE
Fix double indentation in PrettyPrinter.group()

### DIFF
--- a/pretty.py
+++ b/pretty.py
@@ -126,8 +126,7 @@ class _PrettyPrinterBase(object):
         """like begin_group / end_group but for the with statement."""
         self.begin_group(indent, open)
         try:
-            with self.indent(indent):
-                yield
+            yield
         finally:
             self.end_group(indent, close)
 


### PR DESCRIPTION
Currently, `with p.group(n, ...)` indents the lines inside to 2n, not n, because it mistakenly uses both `begin_group` and `indent`. Fix this.